### PR TITLE
Expedite/33 adiciona data ao pedido

### DIFF
--- a/src/main/java/com/thoughtworks/aceleradora/controladores/PedidoControlador.java
+++ b/src/main/java/com/thoughtworks/aceleradora/controladores/PedidoControlador.java
@@ -3,8 +3,6 @@ package com.thoughtworks.aceleradora.controladores;
 import com.thoughtworks.aceleradora.dominio.*;
 import com.thoughtworks.aceleradora.dominio.excecoes.ListaNaoEncontradaExcecao;
 import com.thoughtworks.aceleradora.servicos.*;
-import com.thoughtworks.aceleradora.dominio.*;
-import com.thoughtworks.aceleradora.servicos.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;

--- a/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
+++ b/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 import javax.persistence.*;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
@@ -16,6 +17,7 @@ public class Pedido {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
     private String nome;
+    private LocalDate data;
 
     @ManyToOne
     @JoinColumn(name = "id_clientes")
@@ -52,6 +54,14 @@ public class Pedido {
 
     public void setCliente(Cliente cliente) {
         this.cliente = cliente;
+    }
+
+    public LocalDate getData() {
+        return data;
+    }
+
+    public void setData(LocalDate data) {
+        this.data = data;
     }
 
     public List<PedidoProdutoProdutor> getPedidosProdutosProdutores() {

--- a/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
+++ b/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
@@ -1,9 +1,12 @@
 package com.thoughtworks.aceleradora.dominio;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import jdk.jfr.Timespan;
+import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
 
+import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.util.List;
 
@@ -17,7 +20,9 @@ public class Pedido {
     @GeneratedValue(strategy = IDENTITY)
     private Long id;
     private String nome;
-    private LocalDate data;
+
+    @CreationTimestamp
+    private Timestamp created_at;
 
     @ManyToOne
     @JoinColumn(name = "id_clientes")
@@ -56,12 +61,12 @@ public class Pedido {
         this.cliente = cliente;
     }
 
-    public LocalDate getData() {
-        return data;
+    public Timestamp getCreated_at() {
+        return created_at;
     }
 
-    public void setData(LocalDate data) {
-        this.data = data;
+    public void setCreated_at(Timestamp created_at) {
+        this.created_at = created_at;
     }
 
     public List<PedidoProdutoProdutor> getPedidosProdutosProdutores() {

--- a/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
+++ b/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
@@ -19,7 +19,7 @@ public class Pedido {
     private String nome;
 
     @CreationTimestamp
-    @Column(name = "created_at")
+    @Column(name = "criado_em")
     private Timestamp criadoEm;
 
     @ManyToOne

--- a/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
+++ b/src/main/java/com/thoughtworks/aceleradora/dominio/Pedido.java
@@ -1,13 +1,10 @@
 package com.thoughtworks.aceleradora.dominio;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import jdk.jfr.Timespan;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
-
 import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.util.List;
 
 import static javax.persistence.GenerationType.IDENTITY;
@@ -22,7 +19,8 @@ public class Pedido {
     private String nome;
 
     @CreationTimestamp
-    private Timestamp created_at;
+    @Column(name = "created_at")
+    private Timestamp criadoEm;
 
     @ManyToOne
     @JoinColumn(name = "id_clientes")
@@ -61,12 +59,12 @@ public class Pedido {
         this.cliente = cliente;
     }
 
-    public Timestamp getCreated_at() {
-        return created_at;
+    public Timestamp getCriadoEm() {
+        return criadoEm;
     }
 
-    public void setCreated_at(Timestamp created_at) {
-        this.created_at = created_at;
+    public void setCriadoEm(Timestamp criadoEm) {
+        this.criadoEm = criadoEm;
     }
 
     public List<PedidoProdutoProdutor> getPedidosProdutosProdutores() {

--- a/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
+++ b/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
@@ -6,10 +6,10 @@ import com.thoughtworks.aceleradora.repositorios.PedidoRepositorio;
 import com.thoughtworks.aceleradora.repositorios.ProdutoProdutorRepositorio;
 import org.springframework.stereotype.Service;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -19,6 +19,7 @@ public class PedidoServico {
 
     private ClienteServico clienteServico;
 
+    private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
 
     public PedidoServico(PedidoRepositorio repositorio,
                          ClienteServico clienteServico) {
@@ -52,6 +53,8 @@ public class PedidoServico {
                 .collect(Collectors.toList())
         );
 
+        pedido.setData(LocalDate.now());
+
         return repositorio.save(pedido);
     }
 
@@ -71,4 +74,5 @@ public class PedidoServico {
                 .collect(Collectors.groupingBy(ProdutoProdutor::getProdutor));
         return byProdutor;
     }
+
 }

--- a/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
+++ b/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
@@ -51,8 +51,6 @@ public class PedidoServico {
                 .collect(Collectors.toList())
         );
 
-        pedido.setData(LocalDate.now());
-
         return repositorio.save(pedido);
     }
 

--- a/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
+++ b/src/main/java/com/thoughtworks/aceleradora/servicos/PedidoServico.java
@@ -19,8 +19,6 @@ public class PedidoServico {
 
     private ClienteServico clienteServico;
 
-    private static final DateTimeFormatter dtf = DateTimeFormatter.ofPattern("yyyy/MM/dd HH:mm:ss");
-
     public PedidoServico(PedidoRepositorio repositorio,
                          ClienteServico clienteServico) {
         this.repositorio = repositorio;

--- a/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
+++ b/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
@@ -1,0 +1,2 @@
+alter table pedidos
+add column data date;

--- a/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
+++ b/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
@@ -1,2 +1,2 @@
 alter table pedidos
-add column data date;
+add column created_at timestamp;

--- a/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
+++ b/src/main/resources/db/migration/V38__Alter_table_pedidos_adiciona_data.sql
@@ -1,2 +1,2 @@
 alter table pedidos
-add column created_at timestamp;
+add column criado_em timestamp;

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -39,6 +39,10 @@
                     <td>
                       <span class="flex start" th:text="${pedido.nome}"></span>
                     </td>
+                    <td>
+                      <span type="date"
+                               class="form-control" th:value="${{pedido.data}}" th:text="${{pedido.data}}"><span>
+                    </td>
                     <td class="flex end">
                       <a class="button rz-button list-style"
                         th:href="@{/pedidos/{id}/visualizar-pedido(id=${pedido.id})}">

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -8,66 +8,66 @@
 </head>
 
 <body>
-  <section class="section">
-    <section class="container">
-      <h1 class="title centraliza-texto">Meus Pedidos</h1>
-      <div th:if="${mensagem}">
-        <script th:inline="javascript">
-          /*<![CDATA[*/
-          window.onload = function () {
-            window.Modal
-              .success()
-              .okAction("Ok")
-              .show(/*[[${mensagem}]]*/)
-          };
-          /*]]>*/
-        </script>
-      </div>
-      <div>
-        <p th:if="${pedidosCriados.isEmpty()}">Não há listas criadas.</p>
-      </div>
-      <div class="columns">
-        <div class="column is-12">
-          <div class="box rz-box">
-            <div class="rz-box-body px-0 pb-0">
-              <table class="rz-table striped">
-                <thead class="table-header">
-                  <th class="flex start pl-3">Pedidos</th>
-                  <th class="flex flex-row center pl-3">Data de Emissão</th>
-                </thead>
-                <tbody class="table-body">
-                  <tr th:each="pedido: ${pedidosCriados}">
-                    <td>
-                      <span class="flex start" th:text="${pedido.nome}"></span>
-                    </td>
-                    <td>
-                      <span type="date"
-                               class="form-control" th:value="${{pedido.data}}" th:text="${{pedido.data}}"></span>
-                    </td>
-                    <td class="flex end">
-                      <a class="button rz-button list-style"
-                        th:href="@{/pedidos/{id}/visualizar-pedido(id=${pedido.id})}">
-                        <i class="fas fa-eye"></i></a>
-                      <form th:action="@{/pedidos/{id}/excluir(id=${pedido.id})}" method="post" name="meuform"
+<section class="section">
+  <section class="container">
+    <h1 class="title centraliza-texto">Meus Pedidos</h1>
+    <div th:if="${mensagem}">
+      <script th:inline="javascript">
+        /*<![CDATA[*/
+        window.onload = function () {
+          window.Modal
+                  .success()
+                  .okAction("Ok")
+                  .show(/*[[${mensagem}]]*/)
+        };
+        /*]]>*/
+      </script>
+    </div>
+    <div>
+      <p th:if="${pedidosCriados.isEmpty()}">Não há listas criadas.</p>
+    </div>
+    <div class="columns">
+      <div class="column is-12">
+        <div class="box rz-box">
+          <div class="rz-box-body px-0 pb-0">
+            <table class="rz-table striped">
+              <thead class="table-header">
+              <th class="flex start pl-3">Pedidos</th>
+              <th class="flex flex-row center pl-3">Data de Emissão</th>
+              </thead>
+              <tbody class="table-body">
+              <tr th:each="pedido: ${pedidosCriados}">
+                <td>
+                  <span class="flex start" th:text="${pedido.nome}"></span>
+                </td>
+                <td>
+                      <span type="date" class="form-control" th:value="${{pedido.data}}" th:text="${#temporals.format(pedido.data, 'dd-MMM-yyyy')}">
+                      </span>
+                </td>
+                <td class="flex end">
+                  <a class="button rz-button list-style"
+                     th:href="@{/pedidos/{id}/visualizar-pedido(id=${pedido.id})}">
+                    <i class="fas fa-eye"></i></a>
+                  <form th:action="@{/pedidos/{id}/excluir(id=${pedido.id})}" method="post" name="meuform"
                         th:onsubmit="return Pedidos.exibeConfirmacaoDeExclusaoDoPedido(event)">
-                        <button type="submit" class="button rz-button list-style">
-                          <i class="fas fa-trash-alt"></i>
-                        </button>
-                      </form>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <div class="rz-box-footer flex space-between p-3">
-              <a class="button rz-button is-rounded" th:href="@{/}">Voltar</a>
-              <a class="button rz-button is-rounded" th:href="@{/minhas-listas}">Novo Pedido</a>
-            </div>
+                    <button type="submit" class="button rz-button list-style">
+                      <i class="fas fa-trash-alt"></i>
+                    </button>
+                  </form>
+                </td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+          <div class="rz-box-footer flex space-between p-3">
+            <a class="button rz-button is-rounded" th:href="@{/}">Voltar</a>
+            <a class="button rz-button is-rounded" th:href="@{/minhas-listas}">Novo Pedido</a>
           </div>
         </div>
       </div>
-    </section>
+    </div>
   </section>
+</section>
 </body>
 
 </html>

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -32,8 +32,8 @@
           <div class="rz-box-body px-0 pb-0">
             <table class="rz-table striped">
               <thead class="table-header">
-              <th class="flex start pl-3">Pedidos</th>
-              <th class="flex flex-row center pl-3">Data de Emissão</th>
+              <th>Pedidos</th>
+              <th>Data de Emissão</th>
               </thead>
               <tbody class="table-body">
               <tr th:each="pedido: ${pedidosCriados}">

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -41,7 +41,7 @@
                   <span class="flex start" th:text="${pedido.nome}"></span>
                 </td>
                 <td>
-                      <span type="date" class="form-control" th:value="${{pedido.created_at}}" th:text="${#dates.format(pedido.created_at, 'dd-MMM-yyyy')}">
+                      <span type="date" class="form-control" th:value="${{pedido.criadoEm}}" th:text="${#dates.format(pedido.criadoEm, 'dd-MMM-yyyy')}">
                       </span>
                 </td>
                 <td class="flex end">

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -41,7 +41,7 @@
                   <span class="flex start" th:text="${pedido.nome}"></span>
                 </td>
                 <td>
-                      <span type="date" class="form-control" th:value="${{pedido.data}}" th:text="${#temporals.format(pedido.data, 'dd-MMM-yyyy')}">
+                      <span type="date" class="form-control" th:value="${{pedido.created_at}}" th:text="${#dates.format(pedido.created_at, 'dd-MMM-yyyy')}">
                       </span>
                 </td>
                 <td class="flex end">

--- a/src/main/resources/templates/pedido/pedidos.html
+++ b/src/main/resources/templates/pedido/pedidos.html
@@ -33,6 +33,7 @@
               <table class="rz-table striped">
                 <thead class="table-header">
                   <th class="flex start pl-3">Pedidos</th>
+                  <th class="flex flex-row center pl-3">Data de Emissão</th>
                 </thead>
                 <tbody class="table-body">
                   <tr th:each="pedido: ${pedidosCriados}">
@@ -41,7 +42,7 @@
                     </td>
                     <td>
                       <span type="date"
-                               class="form-control" th:value="${{pedido.data}}" th:text="${{pedido.data}}"><span>
+                               class="form-control" th:value="${{pedido.data}}" th:text="${{pedido.data}}"></span>
                     </td>
                     <td class="flex end">
                       <a class="button rz-button list-style"


### PR DESCRIPTION
Este PR faz:
- Adiciona `pedido.setData(LocalDate.now());` ao final do método `salvarPedido` da classe PedidoServico;
- Adicionamos um `<td>` com para formatar a data vinda do banco `th:text="${#temporals.format(pedido.data, 'dd-MMM-yyyy')}` em `pedido.html`;
- Adiciona o título de cabeçalho `Data de emissão` e alinha os cabeçalhos da tabela: `Pedido` e `Data de emissão`